### PR TITLE
Remove MAIOR instruction usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ I/O. O usuário pode:
 | SAIDA        | 0x10   | Orig            | Escreve byte de Orig no output ASCII                         |
 | INC          | 0x11   | Dest            | Incrementa Dest (Z e C)                                      |
 | DEC          | 0x12   | Dest            | Decrementa Dest (Z e C)                                      |
-| MAIOR        | 0x13   | Dest, R1, R2    | Dest := max(R1, R2) (Z se zero)                              |
 | ZERA         | 0x14   | Dest            | Dest := 0 (Z=1)                                              |
 | LE\_INDIRETO | 0x15   | Dest, Raddr     | Dest := Mem[ Raddr ]                                         |
 | ES\_INDIRETO | 0x16   | Orig, Raddr     | Mem[ Raddr ] := Orig                                         |

--- a/exercicios/ex03_max3.asm
+++ b/exercicios/ex03_max3.asm
@@ -1,9 +1,21 @@
 ; Ex03 - Solicitar três números e imprimir o maior na tela
 START:
-  ENTRADA R0         ; Lê o primeiro número (ASCII) do usuário para R0
-  ENTRADA R1         ; Lê o segundo número (ASCII) para R1
-  MAIOR R0,R0,R1     ; R0 recebe o maior valor entre R0 e R1 (ASCII)
-  ENTRADA R1         ; Lê o terceiro número (ASCII) para R1
-  MAIOR R0,R0,R1     ; R0 recebe o maior valor entre R0 (atual) e R1
-  SAIDA R0           ; Exibe o maior número (ASCII) armazenado em R0
+  ENTRADA R0         ; Lê o primeiro número (ASCII) do usuário
+  ENTRADA R1         ; Lê o segundo número (ASCII)
+  COPIA R2,R0        ; R2 = R0 para comparar com R1
+  SUBTRAI R2,R1      ; R2 = R0 - R1 (C=1 se R0 < R1)
+  SALTA_C USE_R1_1   ; Se R0 < R1, usa R1 como maior
+  SALTA AFTER1       ; Caso contrário, mantém R0
+USE_R1_1:
+  COPIA R0,R1        ; R0 = R1 (novo maior)
+AFTER1:
+  ENTRADA R1         ; Lê o terceiro número (ASCII)
+  COPIA R2,R0        ; R2 = R0 para comparar com R1
+  SUBTRAI R2,R1      ; R2 = R0 - R1
+  SALTA_C USE_R1_2   ; Se R0 < R1, R1 é o maior
+  SALTA AFTER2       ; Caso contrário, mantém R0
+USE_R1_2:
+  COPIA R0,R1        ; R0 = R1
+AFTER2:
+  SAIDA R0           ; Exibe o maior número
   NADA               ; Finaliza a execução do programa

--- a/exercicios/ex04_max10.asm
+++ b/exercicios/ex04_max10.asm
@@ -1,17 +1,21 @@
 ; Ex04 - Solicitar dez números e imprimir o maior na tela
 START:
-  ZERA R2            ; Zera R2 para armazenar o maior valor inicial (0)
-  CAR_IMD R1,10      ; Carrega o contador de entradas (10) em R1
+  ZERA R2            ; Armazena o maior valor (inicia em 0)
+  CAR_IMD R1,10      ; Contador de entradas
 LOOP_READ:
-  ENTRADA R0         ; Lê um número em ASCII do usuário para R0
-  CAR_IMD R3,48      ; Carrega ASCII '0' em R3 para conversão
-  SUBTRAI R0,R3      ; Converte R0 de ASCII para valor numérico
-  MAIOR R2,R2,R0     ; Atualiza R2 com o maior entre R2 (atual) e R0
-  DEC R1             ; Decrementa o contador de entradas
-  SALTA_NZ LOOP_READ ; Se ainda não leu 10, volta para ler o próximo
-
-  ; Impressão do maior valor
-  CAR_IMD R3,48      ; Carrega ASCII '0' em R3 para reconversão
-  SOMA R2,R3         ; Converte R2 de valor numérico para ASCII
-  SAIDA R2           ; Exibe o maior número em ASCII
+  ENTRADA R0         ; Lê um número em ASCII
+  CAR_IMD R3,48      ; '0' para conversão
+  SUBTRAI R0,R3      ; Converte para valor numérico
+  COPIA R3,R2        ; R3 = maior atual
+  SUBTRAI R3,R0      ; Compara maior atual com novo valor
+  SALTA_C UPDATE_MAX ; Se R2 < R0, atualiza maior
+  SALTA AFTER_UPDATE ; Caso contrário, segue
+UPDATE_MAX:
+  COPIA R2,R0        ; R2 recebe o novo maior
+AFTER_UPDATE:
+  DEC R1             ; Decrementa o contador
+  SALTA_NZ LOOP_READ ; Continua até ler 10 números
+  CAR_IMD R3,48      ; Reconversão para ASCII
+  SOMA R2,R3         ; Converte maior para ASCII
+  SAIDA R2           ; Exibe o maior número
   NADA               ; Finaliza o programa


### PR DESCRIPTION
## Summary
- remove `MAIOR` opcode entry from README
- rework exercise 3 to find max using basic instructions
- rework exercise 4 to find max among ten numbers without `MAIOR`

## Testing
- `node --check src/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6865b33f86948333b0c9be49651a71c6